### PR TITLE
api: add syncing endpoint

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -10,6 +10,7 @@ import {
   EnqueueResponse,
   StateRootBatchResponse,
   StateRootResponse,
+  SyncingResponse,
   TransactionBatchResponse,
   TransactionResponse,
 } from '../types'
@@ -17,7 +18,7 @@ import {
 export class L1DataTransportClient {
   constructor(private url: string) {}
 
-  public async syncing(): Promise<boolean> {
+  public async syncing(): Promise<SyncingResponse> {
     return this._get(`/eth/syncing`)
   }
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -17,6 +17,10 @@ import {
 export class L1DataTransportClient {
   constructor(private url: string) {}
 
+  public async syncing(): Promise<boolean> {
+    return this._get(`/eth/syncing`)
+  }
+
   public async getEnqueueByIndex(index: number): Promise<EnqueueResponse> {
     return this._get(`/enqueue/index/${index}`)
   }

--- a/src/db/transport-db.ts
+++ b/src/db/transport-db.ts
@@ -1,4 +1,5 @@
 /* Imports: Internal */
+import { BigNumber } from 'ethers'
 import {
   EnqueueEntry,
   StateRootBatchEntry,
@@ -15,6 +16,7 @@ const TRANSPORT_DB_KEYS = {
   TRANSACTION_BATCH: `batch:transaction`,
   STATE_ROOT: `stateroot`,
   STATE_ROOT_BATCH: `batch:stateroot`,
+  HIGHEST_L2_BLOCK: `l2:highest`,
   HIGHEST_SYNCED_BLOCK: `synced:highest`,
 }
 
@@ -128,6 +130,26 @@ export class TransportDB {
 
   public async getLatestStateRootBatch(): Promise<StateRootBatchEntry> {
     return this._getLatestEntry(TRANSPORT_DB_KEYS.STATE_ROOT_BATCH)
+  }
+
+  public async getHighestL2BlockNumber(): Promise<number> {
+    return this.db.get<number>(TRANSPORT_DB_KEYS.HIGHEST_L2_BLOCK, 0) || 0
+  }
+
+  public async putHighestL2BlockNumber(
+    block: number | BigNumber
+  ): Promise<void> {
+    if (block <= (await this.getHighestL2BlockNumber())) {
+      return
+    }
+
+    return this.db.put<number>([
+      {
+        key: TRANSPORT_DB_KEYS.HIGHEST_L2_BLOCK,
+        index: 0,
+        value: BigNumber.from(block).toNumber(),
+      },
+    ])
   }
 
   public async getHighestSyncedL1Block(): Promise<number> {

--- a/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
+++ b/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
@@ -273,7 +273,7 @@ const maybeDecodeSequencerBatchTransaction = (
 
 export function validateBatchTransaction(
   type: string | null,
-  decoded: DecodedSequencerBatchTransaction | null,
+  decoded: DecodedSequencerBatchTransaction | null
 ): boolean {
   // Unknown types are considered invalid
   if (type === null) {

--- a/src/services/l1-ingestion/service.ts
+++ b/src/services/l1-ingestion/service.ts
@@ -71,6 +71,10 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
         this.state.contracts.Lib_AddressManager.filters.AddressSet()
       )
     )[0].blockNumber
+
+    await this.state.db.putHighestL2BlockNumber(
+      await this.state.contracts.OVM_CanonicalTransactionChain.getTotalElements()
+    )
   }
 
   protected async _start(): Promise<void> {

--- a/src/services/server/service.ts
+++ b/src/services/server/service.ts
@@ -109,6 +109,21 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
 
     this._registerRoute(
       'get',
+      '/eth/syncing',
+      async (): Promise<boolean> => {
+        const highestL2BlockNumber = await this.state.db.getHighestL2BlockNumber()
+        const currentL2Block = await this.state.db.getLatestTransaction()
+
+        if (currentL2Block === null) {
+          return true
+        } else {
+          return highestL2BlockNumber > currentL2Block.index
+        }
+      }
+    )
+
+    this._registerRoute(
+      'get',
       '/eth/context/latest',
       async (): Promise<ContextResponse> => {
         const tip = await this.state.l1RpcProvider.getBlockNumber()

--- a/src/types/api-types.ts
+++ b/src/types/api-types.ts
@@ -35,3 +35,14 @@ export interface ContextResponse {
   timestamp: number
   blockHash: string
 }
+
+export type SyncingResponse =
+  | {
+      syncing: true
+      highestKnownBlock: number
+      currentBlock: number
+    }
+  | {
+      syncing: false
+      currentBlock: number
+    }

--- a/test/unit-tests/services/l1-ingestion/handlers/sequencer-batch-appended.spec.ts
+++ b/test/unit-tests/services/l1-ingestion/handlers/sequencer-batch-appended.spec.ts
@@ -8,15 +8,17 @@ describe.only('Event Handlers: OVM_CanonicalTransactionChain.SequencerBatchAppen
       // CTC index 23159
       const valid = validateBatchTransaction('EIP155', {
         sig: {
-          r: '0x0fbef2080fadc4198ee0d6027e2eb70799d3418574cc085c34a14dcefe14d5d3',
-          s: '0x3bf394a7cb2aca6790e67382f782a406aefce7553212db52b54a4e087c2195ad',
-          v: 56
+          r:
+            '0x0fbef2080fadc4198ee0d6027e2eb70799d3418574cc085c34a14dcefe14d5d3',
+          s:
+            '0x3bf394a7cb2aca6790e67382f782a406aefce7553212db52b54a4e087c2195ad',
+          v: 56,
         },
         gasLimit: 8000000,
         gasPrice: 0,
         nonce: 0,
         target: '0x1111111111111111111111111111111111111111',
-        data: '0x1234'
+        data: '0x1234',
       })
 
       expect(valid).to.be.false


### PR DESCRIPTION
Adds a new endpoint `/eth/syncing` to represent that we're still synchronizing information from L1. Maybe `/eth/` prefix should be changed though.