### PR TITLE
Minor tweaks to fix sync statuses

### DIFF
--- a/src/db/transport-db.ts
+++ b/src/db/transport-db.ts
@@ -133,7 +133,7 @@ export class TransportDB {
   }
 
   public async getHighestL2BlockNumber(): Promise<number> {
-    return this.db.get<number>(TRANSPORT_DB_KEYS.HIGHEST_L2_BLOCK, 0) || 0
+    return this.db.get<number>(TRANSPORT_DB_KEYS.HIGHEST_L2_BLOCK, 0)
   }
 
   public async putHighestL2BlockNumber(
@@ -153,7 +153,10 @@ export class TransportDB {
   }
 
   public async getHighestSyncedL1Block(): Promise<number> {
-    return this.db.get<number>(TRANSPORT_DB_KEYS.HIGHEST_SYNCED_BLOCK, 0) || 0
+    return (
+      (await this.db.get<number>(TRANSPORT_DB_KEYS.HIGHEST_SYNCED_BLOCK, 0)) ||
+      0
+    )
   }
 
   public async setHighestSyncedL1Block(block: number): Promise<void> {

--- a/src/services/server/service.ts
+++ b/src/services/server/service.ts
@@ -152,10 +152,17 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
         const currentL2Block = await this.state.db.getLatestTransaction()
 
         if (currentL2Block === null) {
-          return {
-            syncing: true,
-            highestKnownBlock: highestL2BlockNumber,
-            currentBlock: 0,
+          if (highestL2BlockNumber === null) {
+            return {
+              syncing: false,
+              currentBlock: 0,
+            }
+          } else {
+            return {
+              syncing: true,
+              highestKnownBlock: highestL2BlockNumber,
+              currentBlock: 0,
+            }
           }
         }
 


### PR DESCRIPTION
`getHighestL2BlockNumber()` will just officially return `null` when not set. Also fixes an off-by-one error that made clients think we were never done syncing.