### PR TITLE
api: improve `syncing` response

### DIFF
--- a/src/db/transport-db.ts
+++ b/src/db/transport-db.ts
@@ -133,7 +133,7 @@ export class TransportDB {
   }
 
   public async getHighestL2BlockNumber(): Promise<number> {
-    return this.db.get<number>(TRANSPORT_DB_KEYS.HIGHEST_L2_BLOCK, 0) || 0
+    return this.db.get<number>(TRANSPORT_DB_KEYS.HIGHEST_L2_BLOCK, 0)
   }
 
   public async putHighestL2BlockNumber(
@@ -153,7 +153,10 @@ export class TransportDB {
   }
 
   public async getHighestSyncedL1Block(): Promise<number> {
-    return this.db.get<number>(TRANSPORT_DB_KEYS.HIGHEST_SYNCED_BLOCK, 0) || 0
+    return (
+      (await this.db.get<number>(TRANSPORT_DB_KEYS.HIGHEST_SYNCED_BLOCK, 0)) ||
+      0
+    )
   }
 
   public async setHighestSyncedL1Block(block: number): Promise<void> {

--- a/src/services/server/service.ts
+++ b/src/services/server/service.ts
@@ -155,13 +155,13 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
           if (highestL2BlockNumber === null) {
             return {
               syncing: false,
-              currentBlock: 0,
+              currentTransactionIndex: 0,
             }
           } else {
             return {
               syncing: true,
-              highestKnownBlock: highestL2BlockNumber,
-              currentBlock: 0,
+              highestKnownTransactionIndex: highestL2BlockNumber,
+              currentTransactionIndex: 0,
             }
           }
         }
@@ -169,13 +169,13 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
         if (highestL2BlockNumber > currentL2Block.index) {
           return {
             syncing: true,
-            highestKnownBlock: highestL2BlockNumber,
-            currentBlock: currentL2Block.index,
+            highestKnownTransactionIndex: highestL2BlockNumber,
+            currentTransactionIndex: currentL2Block.index,
           }
         } else {
           return {
             syncing: false,
-            currentBlock: currentL2Block.index,
+            currentTransactionIndex: currentL2Block.index,
           }
         }
       }

--- a/src/services/server/service.ts
+++ b/src/services/server/service.ts
@@ -152,10 +152,17 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
         const currentL2Block = await this.state.db.getLatestTransaction()
 
         if (currentL2Block === null) {
-          return {
-            syncing: true,
-            highestKnownBlock: highestL2BlockNumber,
-            currentBlock: 0,
+          if (highestL2BlockNumber === null) {
+            return {
+              syncing: false,
+              currentBlock: 0,
+            }
+          } else {
+            return {
+              syncing: true,
+              highestKnownBlock: highestL2BlockNumber,
+              currentBlock: 0,
+            }
           }
         }
 

--- a/src/types/api-types.ts
+++ b/src/types/api-types.ts
@@ -39,10 +39,10 @@ export interface ContextResponse {
 export type SyncingResponse =
   | {
       syncing: true
-      highestKnownBlock: number
-      currentBlock: number
+      highestKnownTransactionIndex: number
+      currentTransactionIndex: number
     }
   | {
       syncing: false
-      currentBlock: number
+      currentTransactionIndex: number
     }


### PR DESCRIPTION
Makes the response for `/eth/syncing` a little better, using `transactionIndex` instead of `block`. @tynes should we replace the `/eth/` prefix? If so, `/l2/`?