### PR TITLE
l1-ingestion: fix so we can sync without infura's caching

### DIFF
--- a/src/db/transport-db.ts
+++ b/src/db/transport-db.ts
@@ -16,6 +16,7 @@ const TRANSPORT_DB_KEYS = {
   TRANSACTION_BATCH: `batch:transaction`,
   STATE_ROOT: `stateroot`,
   STATE_ROOT_BATCH: `batch:stateroot`,
+  STARTING_L1_BLOCK: `l1:starting`,
   HIGHEST_L2_BLOCK: `l2:highest`,
   HIGHEST_SYNCED_BLOCK: `synced:highest`,
 }
@@ -163,6 +164,20 @@ export class TransportDB {
     return this.db.put<number>([
       {
         key: TRANSPORT_DB_KEYS.HIGHEST_SYNCED_BLOCK,
+        index: 0,
+        value: block,
+      },
+    ])
+  }
+
+  public async getStartingL1Block(): Promise<number> {
+    return this.db.get<number>(TRANSPORT_DB_KEYS.STARTING_L1_BLOCK, 0)
+  }
+
+  public async setStartingL1Block(block: number): Promise<void> {
+    return this.db.put<number>([
+      {
+        key: TRANSPORT_DB_KEYS.STARTING_L1_BLOCK,
         index: 0,
         value: block,
       },

--- a/src/services/l1-ingestion/service.ts
+++ b/src/services/l1-ingestion/service.ts
@@ -112,6 +112,8 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
           `${this.state.startingL1BlockNumber}`
         )}`
       )
+
+      await this.state.db.setStartingL1Block(this.state.startingL1BlockNumber)
     }
 
     // Store the total number of submitted transactions so the server can tell clients if we're

--- a/src/services/l1-ingestion/service.ts
+++ b/src/services/l1-ingestion/service.ts
@@ -104,7 +104,7 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
       this.state.startingL1BlockNumber = startingL1BlockNumber
     } else {
       this.logger.info(
-        `Attempting to find an appropriate L1 block height to being sync...`
+        `Attempting to find an appropriate L1 block height to begin sync...`
       )
       this.state.startingL1BlockNumber = await this._findStartingL1BlockNumber()
       this.logger.info(


### PR DESCRIPTION
Infura does some *infura*iating caching that, while efficient, means we can't simply replace our providers with Infura and expect everything to work. This PR fixes that issue.