### PR TITLE
Add typings for LevelDB object and update process config options

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,8 +28,9 @@ jobs:
               GITHUB_HEAD_REF=${GITHUB_REF##*/}
           fi
           GIT_COMMIT=$(git rev-parse HEAD | head -c 8)
+          REMOTE="https://github.com/${{ github.repository }}"
           echo "optimism-integration $GIT_COMMIT"
-          ./docker/build.sh -s data-transport-layer -b $GITHUB_HEAD_REF
+          ./docker/build.sh -s data-transport-layer -b $GITHUB_HEAD_REF -r $REMOTE
 
       - name: Test
         run: |

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ethers": "^5.0.26",
     "express": "^4.17.1",
     "level": "^6.0.1",
+    "levelup": "^4.4.0",
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {
@@ -41,6 +42,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.1",
     "@types/browser-or-node": "^1.3.0",
     "@types/cors": "^2.8.9",
+    "@types/levelup": "^4.3.0",
     "@types/node-fetch": "^2.5.8",
     "@types/rimraf": "^3.0.0",
     "hardhat": "^2.0.9"

--- a/src/db/simple-db.ts
+++ b/src/db/simple-db.ts
@@ -1,9 +1,9 @@
-/* Imports: Internal */
+/* Imports: External */
+import { LevelUp } from 'levelup'
 import { BigNumber } from 'ethers'
 
 export class SimpleDB {
-  // TODO: Ugh, we need a type for this db.
-  constructor(public db: any) {}
+  constructor(public db: LevelUp) {}
 
   public async get<TEntry>(key: string, index: number): Promise<TEntry | null> {
     try {

--- a/src/db/transport-db.ts
+++ b/src/db/transport-db.ts
@@ -1,5 +1,8 @@
-/* Imports: Internal */
+/* Imports: External */
+import { LevelUp } from 'levelup'
 import { BigNumber } from 'ethers'
+
+/* Imports: Internal */
 import {
   EnqueueEntry,
   StateRootBatchEntry,
@@ -30,7 +33,7 @@ interface Indexed {
 export class TransportDB {
   public db: SimpleDB
 
-  constructor(leveldb: any) {
+  constructor(leveldb: LevelUp) {
     this.db = new SimpleDB(leveldb)
   }
 

--- a/src/services/l1-ingestion/service.ts
+++ b/src/services/l1-ingestion/service.ts
@@ -3,6 +3,7 @@ import { BaseService } from '@eth-optimism/service-base'
 import { fromHexString, ZERO_ADDRESS } from '@eth-optimism/core-utils'
 import { JsonRpcProvider } from '@ethersproject/providers'
 import colors from 'colors/safe'
+import { LevelUp } from 'levelup'
 
 /* Imports: Internal */
 import { TransportDB } from '../../db/transport-db'
@@ -21,15 +22,11 @@ import {
 import { handleEventsTransactionEnqueued } from './handlers/transaction-enqueued'
 import { handleEventsSequencerBatchAppended } from './handlers/sequencer-batch-appended'
 import { handleEventsStateBatchAppended } from './handlers/state-batch-appended'
+import { L1DataTransportServiceOptions } from '../main/service'
 
-export interface L1IngestionServiceOptions {
-  db: any
-  addressManager: string
-  confirmations: number
-  l1RpcProvider: string | JsonRpcProvider
-  pollingInterval: number
-  logsPerPollingInterval: number
-  dangerouslyCatchAllErrors?: boolean
+export interface L1IngestionServiceOptions
+  extends L1DataTransportServiceOptions {
+  db: LevelUp
 }
 
 export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {

--- a/src/services/l2-ingestion/service.ts
+++ b/src/services/l2-ingestion/service.ts
@@ -2,19 +2,17 @@
 import { BaseService } from '@eth-optimism/service-base'
 import { JsonRpcProvider } from '@ethersproject/providers'
 import colors from 'colors/safe'
+import { LevelUp } from 'levelup'
 
 /* Imports: Internal */
 import { TransportDB } from '../../db/transport-db'
 import { sleep, toRpcHexString, validators } from '../../utils'
+import { L1DataTransportServiceOptions } from '../main/service'
 import { handleSequencerBlock } from './handlers/transaction'
 
-export interface L2IngestionServiceOptions {
-  db: any
-  l2RpcProvider: string | JsonRpcProvider
-  l2ChainId: number
-  pollingInterval: number
-  transactionsPerPollingInterval: number
-  dangerouslyCatchAllErrors?: boolean
+export interface L2IngestionServiceOptions
+  extends L1DataTransportServiceOptions {
+  db: LevelUp
 }
 
 export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {

--- a/src/services/main/service.ts
+++ b/src/services/main/service.ts
@@ -1,25 +1,31 @@
 /* Imports: External */
-import level from 'level'
 import { BaseService } from '@eth-optimism/service-base'
+import { LevelUp } from 'levelup'
+import level from 'level'
 
 /* Imports: Internal */
-import {
-  L1IngestionService,
-  L1IngestionServiceOptions,
-} from '../l1-ingestion/service'
-import { L1TransportServer, L1TransportServerOptions } from '../server/service'
-import {
-  L2IngestionService,
-  L2IngestionServiceOptions,
-} from '../l2-ingestion/service'
+import { L1IngestionService } from '../l1-ingestion/service'
+import { L1TransportServer } from '../server/service'
 import { validators } from '../../utils'
+import { L2IngestionService } from '../l2-ingestion/service'
 
-type L1DataTransportServiceOptions = L1IngestionServiceOptions &
-  L1TransportServerOptions &
-  L2IngestionServiceOptions & {
-    syncFromL1?: boolean
-    syncFromL2?: boolean
-  }
+export interface L1DataTransportServiceOptions {
+  addressManager: string
+  confirmations: number
+  dangerouslyCatchAllErrors?: boolean
+  hostname: string
+  l1RpcProvider: string
+  l2ChainId: number
+  l2RpcProvider: string
+  dbPath: string
+  logsPerPollingInterval: number
+  pollingInterval: number
+  port: number
+  showUnconfirmedTransactions: boolean
+  syncFromL1?: boolean
+  syncFromL2?: boolean
+  transactionsPerPollingInterval: number
+}
 
 export class L1DataTransportService extends BaseService<L1DataTransportServiceOptions> {
   protected name = 'L1 Data Transport Service'
@@ -36,7 +42,7 @@ export class L1DataTransportService extends BaseService<L1DataTransportServiceOp
   }
 
   private state: {
-    db: any
+    db: LevelUp
     l1IngestionService?: L1IngestionService
     l2IngestionService?: L2IngestionService
     l1TransportServer: L1TransportServer
@@ -44,7 +50,7 @@ export class L1DataTransportService extends BaseService<L1DataTransportServiceOp
 
   protected async _init(): Promise<void> {
     console.log(this.options)
-    this.state.db = level(this.options.db)
+    this.state.db = level(this.options.dbPath)
     await this.state.db.open()
 
     this.state.l1TransportServer = new L1TransportServer({

--- a/src/services/run.ts
+++ b/src/services/run.ts
@@ -23,7 +23,7 @@ interface Bcfg {
     })
 
     const service = new L1DataTransportService({
-      db: config.str('dbPath', './db'),
+      dbPath: config.str('dbPath', './db'),
       port: config.uint('serverPort', 7878),
       hostname: config.str('serverHostname', 'localhost'),
       confirmations: config.uint('confirmations', 12),

--- a/src/services/server/service.ts
+++ b/src/services/server/service.ts
@@ -4,6 +4,7 @@ import express, { Request, Response } from 'express'
 import cors from 'cors'
 import { BigNumber } from 'ethers'
 import { JsonRpcProvider } from '@ethersproject/providers'
+import { LevelUp } from 'levelup'
 
 /* Imports: Internal */
 import { TransportDB } from '../../db/transport-db'
@@ -17,14 +18,11 @@ import {
   TransactionResponse,
 } from '../../types'
 import { validators } from '../../utils'
+import { L1DataTransportServiceOptions } from '../main/service'
 
-export interface L1TransportServerOptions {
-  db: any
-  port: number
-  hostname: string
-  confirmations: number
-  l1RpcProvider: string | JsonRpcProvider
-  showUnconfirmedTransactions: boolean
+export interface L1TransportServerOptions
+  extends L1DataTransportServiceOptions {
+  db: LevelUp
 }
 
 export class L1TransportServer extends BaseService<L1TransportServerOptions> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -665,6 +665,11 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@types/abstract-leveldown@*":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@types/abstract-leveldown/-/abstract-leveldown-5.0.1.tgz#3c7750d0186b954c7f2d2f6acc8c3c7ba0c3412e"
+  integrity sha512-wYxU3kp5zItbxKmeRYCEplS2MW7DzyBnxPGj+GJVHZEUZiK/nn5Ei1sUFgURDh+X051+zsGe28iud3oHjrYWQQ==
+
 "@types/bn.js@^4.11.3", "@types/bn.js@^4.11.5":
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"
@@ -734,6 +739,14 @@
   integrity sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==
   dependencies:
     "@types/minimatch" "*"
+    "@types/node" "*"
+
+"@types/levelup@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@types/levelup/-/levelup-4.3.0.tgz#4f55585e05a33caa08c1439c344bbba93e947327"
+  integrity sha512-h82BoajhjU/zwLoM4BUBX/SCodCFi1ae/ZlFOYh5Z4GbHeaXj9H709fF1LYl/StrK8KSwnJOeMRPo9lnC6sz4w==
+  dependencies:
+    "@types/abstract-leveldown" "*"
     "@types/node" "*"
 
 "@types/lru-cache@^5.1.0":
@@ -4907,7 +4920,7 @@ levelup@^1.2.1:
     semver "~5.4.1"
     xtend "~4.0.0"
 
-levelup@^4.3.2:
+levelup@^4.3.2, levelup@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/levelup/-/levelup-4.4.0.tgz#f89da3a228c38deb49c48f88a70fb71f01cafed6"
   integrity sha512-94++VFO3qN95cM/d6eBXvd894oJE0w3cInq9USsyQzzoJxmiYzPAocNcuGCPGGjoXqDVJcr3C1jzt1TSjyaiLQ==


### PR DESCRIPTION
Adds `@types/levelup` to the repository and types the `db` object inside of the `L1IngestionService` and `L1TransportServer`. 

While doing this, I noticed the configuration option `db` was also ambiguously being typed (and re-used) for both the path to the database file extracted from the environment _and_ the eventually instantiated `level` instance. This was confusing, so I renamed the external option on `L1DataTransportServiceOptions` to `dbPath` and explicitly de-coupled it from the aforementioned `db` option.