### PR TITLE
ci: fix for outside contributors

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,8 +28,9 @@ jobs:
               GITHUB_HEAD_REF=${GITHUB_REF##*/}
           fi
           GIT_COMMIT=$(git rev-parse HEAD | head -c 8)
+          REMOTE="https://github.com/${{ github.repository }}"
           echo "optimism-integration $GIT_COMMIT"
-          ./docker/build.sh -s data-transport-layer -b $GITHUB_HEAD_REF
+          ./docker/build.sh -s data-transport-layer -b $GITHUB_HEAD_REF -r $REMOTE
 
       - name: Test
         run: |


### PR DESCRIPTION
Passes through the remote so that the context independent docker images can build by cloning from github as part of their build process