### PR TITLE
fix: prevent syncsequencerblock bad query

### DIFF
--- a/src/services/l2-ingestion/service.ts
+++ b/src/services/l2-ingestion/service.ts
@@ -133,6 +133,10 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
     startBlockNumber: number,
     endBlockNumber: number
   ): Promise<void> {
+    if (startBlockNumber > endBlockNumber) {
+      return
+    }
+
     const blocks = await this.state.l2RpcProvider.send('eth_getBlockRange', [
       toRpcHexString(startBlockNumber),
       toRpcHexString(endBlockNumber),

--- a/src/services/l2-ingestion/service.ts
+++ b/src/services/l2-ingestion/service.ts
@@ -79,7 +79,9 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
   protected async _start(): Promise<void> {
     while (this.running) {
       try {
-        const currentL2Block = await this.state.l2RpcProvider.getBlockNumber()
+        // Subtract one to account for the CTC being zero indexed
+        const currentL2Block =
+          (await this.state.l2RpcProvider.getBlockNumber()) - 1
         const targetL2Block = Math.min(
           this.state.highestSyncedL2BlockNumber +
             this.options.transactionsPerPollingInterval,
@@ -134,6 +136,10 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
     endBlockNumber: number
   ): Promise<void> {
     if (startBlockNumber > endBlockNumber) {
+      this.logger.info(
+        `Cannot query with start block number ${startBlockNumber}` +
+          `larger than end block number ${endBlockNumber}`
+      )
       return
     }
 


### PR DESCRIPTION
Closes https://github.com/ethereum-optimism/data-transport-layer/issues/51

Another solution would be to manage the start and end blocks such that this function is only called with sane arguments. That feels a little more ideal, but this definitely will prevent invalid queries. Thoughts @kfichter? 