### PR TITLE
[Fix] Run integration tests in forked context

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,8 +28,9 @@ jobs:
               GITHUB_HEAD_REF=${GITHUB_REF##*/}
           fi
           GIT_COMMIT=$(git rev-parse HEAD | head -c 8)
+          REMOTE={{ github.event.pull_request.head.repo.html_url }}
           echo "optimism-integration $GIT_COMMIT"
-          ./docker/build.sh -s data-transport-layer -b $GITHUB_HEAD_REF -r ${{ github.event.pull_request.head.repo.html_url }}
+          ./docker/build.sh -s data-transport-layer -b $GITHUB_HEAD_REF -r $REMOTE
 
       - name: Test
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,9 +28,8 @@ jobs:
               GITHUB_HEAD_REF=${GITHUB_REF##*/}
           fi
           GIT_COMMIT=$(git rev-parse HEAD | head -c 8)
-          REMOTE="https://github.com/${{ github.repository }}"
           echo "optimism-integration $GIT_COMMIT"
-          ./docker/build.sh -s data-transport-layer -b $GITHUB_HEAD_REF -r $REMOTE
+          ./docker/build.sh -s data-transport-layer -b $GITHUB_HEAD_REF -r ${{ github.event.pull_request.head.repo.html_url }}
 
       - name: Test
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,7 +28,7 @@ jobs:
               GITHUB_HEAD_REF=${GITHUB_REF##*/}
           fi
           GIT_COMMIT=$(git rev-parse HEAD | head -c 8)
-          REMOTE={{ github.event.pull_request.head.repo.html_url }}
+          REMOTE=${{ github.event.pull_request.head.repo.html_url }}
           echo "optimism-integration $GIT_COMMIT"
           ./docker/build.sh -s data-transport-layer -b $GITHUB_HEAD_REF -r $REMOTE
 


### PR DESCRIPTION
Addresses ethereum-optimism/roadmap#643

This PR attempts to move the CI logic to run in the forked context instead of in our home repo.