### PR TITLE
Add a jank temporary sync method

### DIFF
--- a/src/services/l2-ingestion/service.ts
+++ b/src/services/l2-ingestion/service.ts
@@ -77,12 +77,26 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
       try {
         const highestSyncedL2BlockNumber =
           (await this.state.db.getHighestSyncedUnconfirmedBlock()) || 1
+
+        // Shut down if we're at the stop block.
+        if (
+          this.options.stopL2SyncAtBlock !== undefined &&
+          this.options.stopL2SyncAtBlock !== null &&
+          highestSyncedL2BlockNumber >= this.options.stopL2SyncAtBlock
+        ) {
+          this.logger.interesting(
+            `L2 sync is shutting down because we've reached your target block. Goodbye!`
+          )
+          return
+        }
+
         // Subtract one to account for the CTC being zero indexed
         let currentL2Block = Math.max(
           (await this.state.l2RpcProvider.getBlockNumber()) - 1,
           0
         )
 
+        // Make sure we can't exceed the stop block.
         if (
           this.options.stopL2SyncAtBlock !== undefined &&
           this.options.stopL2SyncAtBlock !== null
@@ -93,6 +107,7 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
           )
         }
 
+        // Make sure we don't exceed the tip.
         const targetL2Block = Math.min(
           highestSyncedL2BlockNumber +
             this.options.transactionsPerPollingInterval,

--- a/src/services/main/service.ts
+++ b/src/services/main/service.ts
@@ -26,6 +26,7 @@ export interface L1DataTransportServiceOptions {
   syncFromL2?: boolean
   transactionsPerPollingInterval: number
   legacySequencerCompatibility: boolean
+  stopL2SyncAtBlock?: number
 }
 
 export class L1DataTransportService extends BaseService<L1DataTransportServiceOptions> {

--- a/src/services/run.ts
+++ b/src/services/run.ts
@@ -48,6 +48,7 @@ interface Bcfg {
         'legacySequencerCompatibility',
         false
       ),
+      stopL2SyncAtBlock: config.uint('stopL2SyncAtBlock'),
     })
 
     await service.start()

--- a/src/services/server/service.ts
+++ b/src/services/server/service.ts
@@ -280,7 +280,9 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
         let transaction = null
         if (this.options.showUnconfirmedTransactions) {
           transaction = await this.state.db.getLatestUnconfirmedTransaction()
-        } else {
+        }
+
+        if (transaction === null) {
           transaction = await this.state.db.getLatestFullTransaction()
         }
 
@@ -311,7 +313,9 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
           transaction = await this.state.db.getUnconfirmedTransactionByIndex(
             BigNumber.from(req.params.index).toNumber()
           )
-        } else {
+        }
+
+        if (transaction === null) {
           transaction = await this.state.db.getFullTransactionByIndex(
             BigNumber.from(req.params.index).toNumber()
           )
@@ -396,7 +400,9 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
         let stateRoot = null
         if (this.options.showUnconfirmedTransactions) {
           stateRoot = await this.state.db.getLatestUnconfirmedStateRoot()
-        } else {
+        }
+
+        if (stateRoot === null) {
           stateRoot = await this.state.db.getLatestStateRoot()
         }
 
@@ -427,7 +433,9 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
           stateRoot = await this.state.db.getUnconfirmedStateRootByIndex(
             BigNumber.from(req.params.index).toNumber()
           )
-        } else {
+        }
+
+        if (stateRoot === null) {
           stateRoot = await this.state.db.getStateRootByIndex(
             BigNumber.from(req.params.index).toNumber()
           )


### PR DESCRIPTION
Basically forces L2 sync to stop after a certain point. Useful if you want to bootstrap as a replica but continue on your own. Automatically switches to providing L1 results for newer blocks because the L2 results won't exist.