### PR TITLE
config: default stop l2 sync at block value

### DIFF
--- a/src/services/l2-ingestion/service.ts
+++ b/src/services/l2-ingestion/service.ts
@@ -48,6 +48,7 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
       validate: validators.isBoolean,
     },
     stopL2SyncAtBlock: {
+      default: Infinity,
       validate: validators.isInteger,
     },
   }


### PR DESCRIPTION
By default, never stop syncing the L2 when sync from L2 is enabled