### PR TITLE
fix: ensure latest transaction will always be displayed

### DIFF
--- a/src/services/server/service.ts
+++ b/src/services/server/service.ts
@@ -280,7 +280,11 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
         let transaction = await this.state.db.getLatestFullTransaction()
         if (this.options.showUnconfirmedTransactions) {
           const latestUnconfirmedTx = await this.state.db.getLatestUnconfirmedTransaction()
-          if (latestUnconfirmedTx.index > transaction.index) {
+          if (
+            transaction === null ||
+            transaction === undefined ||
+            latestUnconfirmedTx.index >= transaction.index
+          ) {
             transaction = latestUnconfirmedTx
           }
         }
@@ -403,7 +407,11 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
         let stateRoot = await this.state.db.getLatestStateRoot()
         if (this.options.showUnconfirmedTransactions) {
           const latestUnconfirmedStateRoot = await this.state.db.getLatestUnconfirmedStateRoot()
-          if (latestUnconfirmedStateRoot.index > stateRoot.index) {
+          if (
+            stateRoot === null ||
+            stateRoot === undefined ||
+            latestUnconfirmedStateRoot.index >= stateRoot.index
+          ) {
             stateRoot = latestUnconfirmedStateRoot
           }
         }

--- a/src/services/server/service.ts
+++ b/src/services/server/service.ts
@@ -277,11 +277,10 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
       'get',
       '/transaction/latest',
       async (): Promise<TransactionResponse> => {
-        let transaction = null
+        let transaction = await this.state.db.getLatestFullTransaction()
         if (this.options.showUnconfirmedTransactions) {
           const latestUnconfirmedTx = await this.state.db.getLatestUnconfirmedTransaction()
-          const latestConfirmedTx = await this.state.db.getLatestFullTransaction()
-          if (latestUnconfirmedTx.index > latestConfirmedTx.index) {
+          if (latestUnconfirmedTx.index > transaction.index) {
             transaction = latestUnconfirmedTx
           }
         }
@@ -401,11 +400,10 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
       'get',
       '/stateroot/latest',
       async (): Promise<StateRootResponse> => {
-        let stateRoot = null
+        let stateRoot = await this.state.db.getLatestStateRoot()
         if (this.options.showUnconfirmedTransactions) {
           const latestUnconfirmedStateRoot = await this.state.db.getLatestUnconfirmedStateRoot()
-          const latestConfirmedStateRoot = await this.state.db.getLatestStateRoot()
-          if (latestUnconfirmedStateRoot.index > latestConfirmedStateRoot.index) {
+          if (latestUnconfirmedStateRoot.index > stateRoot.index) {
             stateRoot = latestUnconfirmedStateRoot
           }
         }

--- a/src/services/server/service.ts
+++ b/src/services/server/service.ts
@@ -279,7 +279,11 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
       async (): Promise<TransactionResponse> => {
         let transaction = null
         if (this.options.showUnconfirmedTransactions) {
-          transaction = await this.state.db.getLatestUnconfirmedTransaction()
+          const latestUnconfirmedTx = await this.state.db.getLatestUnconfirmedTransaction()
+          const latestConfirmedTx = await this.state.db.getLatestFullTransaction()
+          if (latestUnconfirmedTx.index > latestConfirmedTx.index) {
+            transaction = latestUnconfirmedTx
+          }
         }
 
         if (transaction === null) {
@@ -399,7 +403,11 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
       async (): Promise<StateRootResponse> => {
         let stateRoot = null
         if (this.options.showUnconfirmedTransactions) {
-          stateRoot = await this.state.db.getLatestUnconfirmedStateRoot()
+          const latestUnconfirmedStateRoot = await this.state.db.getLatestUnconfirmedStateRoot()
+          const latestConfirmedStateRoot = await this.state.db.getLatestStateRoot()
+          if (latestUnconfirmedStateRoot.index > latestConfirmedStateRoot.index) {
+            stateRoot = latestUnconfirmedStateRoot
+          }
         }
 
         if (stateRoot === null) {


### PR DESCRIPTION
Fixes a bug where the latest transaction would always be the L2 synced transaction, even if L1 transactions had a higher index.