### PR TITLE
Feat/auto publish

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -35,19 +35,24 @@ jobs:
           draft: false
           prerelease: false
 
-  publish:
-    name: Build and publish
+  docker:
+    name: Build & Push to DockerHub
     runs-on: ubuntu-latest
     needs: tag
     if: needs.tag.outputs.tag_name
+
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14.x'
-          registry-url: 'https://registry.npmjs.org'
-      - run: yarn
-      - run: yarn build
-      - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Login to DockerHub Registry
+        run: echo ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }} | docker login -u ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME}} --password-stdin
+
+      - name: Build and push Optimistic Ethereum Node image to DockerHub
+        run: |
+          git clone https://github.com/ethereum-optimism/docker.git \
+              $HOME/docker
+          cd $HOME/docker
+          ./build.sh -s data-transport-layer -b ${{ needs.tag.outputs.tag_name }}
+          docker push ethereumoptimism/data-transport-layer:${{ needs.tag.outputs.tag_name }}
+      - name: Logout of DockerHub
+        run: docker logout

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,41 +1,53 @@
-name: Create Releases on Tags
+name: Auto tag-release-publish
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - master
 
 jobs:
-  release:
+  tag:
+    name: Create tag for new version
     runs-on: ubuntu-latest
-    steps:
-      - name: Create GitHub release
-        uses: Roang-zero1/github-create-release-action@master
-        with:
-          version_regex: ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  docker:
-    name: Build & Push to DockerHub
-    runs-on: ubuntu-latest
-
+    outputs:
+      tag_name: ${{ steps.create_new_tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - uses: salsify/action-detect-and-tag-new-version@v2
+        id: create_new_tag
 
-      - name: Login to DockerHub Registry
-        run: echo ${{ secrets.DOCKERHUB_ACCESS_TOKEN_SECRET }} | docker login -u ${{ secrets.DOCKERHUB_ACCESS_TOKEN_USERNAME}} --password-stdin
+  release:
+    name: Create release
+    runs-on: ubuntu-latest
+    needs: tag
+    if: needs.tag.outputs.tag_name
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/create-release@v1
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.tag.outputs.tag_name }}
+          release_name: ${{ needs.tag.outputs.tag_name }}
+          draft: false
+          prerelease: false
 
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
-
-      - name: Build and push Optimistic Ethereum Node image to DockerHub
-        run: |
-          git clone https://github.com/ethereum-optimism/docker.git \
-              $HOME/docker
-          cd $HOME/docker
-          ./build.sh -s data-transport-layer -b ${{ steps.get_version.outputs.VERSION }}
-          docker push ethereumoptimism/data-transport-layer:${{ steps.get_version.outputs.VERSION }}
-      - name: Logout of DockerHub
-        run: docker logout
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    needs: tag
+    if: needs.tag.outputs.tag_name
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: yarn
+      - run: yarn build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -35,12 +35,29 @@ jobs:
           draft: false
           prerelease: false
 
+  npm-publish:
+    name: Build & publish to npm
+    runs-on: ubuntu-latest
+    needs: tag
+    if: needs.tag.outputs.tag_name
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: yarn
+      - run: yarn build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+
   docker:
     name: Build & Push to DockerHub
     runs-on: ubuntu-latest
     needs: tag
     if: needs.tag.outputs.tag_name
-
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
This change enables autopublishing from updating the version in `package.json`. 

Note:

`needs.tag.outputs.tag_name` will be in the format of `vX.X.X` - is that correct for docker?
```
./build.sh -s data-transport-layer -b ${{ needs.tag.outputs.tag_name }}
docker push ethereumoptimism/data-transport-layer:${{ steps.get_version.outputs.VERSION }}	          docker push ethereumoptimism/data-transport-layer:${{ needs.tag.outputs.tag_name }}
```