### PR TITLE
feat: Attempt to decode incoming transactions as RLP first.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "colors": "^1.4.0",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
+    "ethereumjs-tx": "^2.1.2",
     "ethers": "^5.0.26",
     "express": "^4.17.1",
     "level": "^6.0.1",


### PR DESCRIPTION
We're switching over to standard RLP encodings so we need the DTL to do this extra work. It adds a bit of overhead for historical transactions (have to try the RLP decoding first for each transaction) but this is ultimately pretty minimal.