### PR TITLE
style: refactor logs to split context and message

### DIFF
--- a/src/services/l1-ingestion/service.ts
+++ b/src/services/l1-ingestion/service.ts
@@ -77,7 +77,9 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
         ? new JsonRpcProvider(this.options.l1RpcProvider)
         : this.options.l1RpcProvider
 
-    this.logger.info(`Using AddressManager at: ${this.options.addressManager}`)
+    this.logger.info('Using AddressManager', {
+      addressManager: this.options.addressManager,
+    })
 
     const Lib_AddressManager = loadContract(
       'Lib_AddressManager',
@@ -119,14 +121,12 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
       this.state.startingL1BlockNumber = startingL1BlockNumber
     } else {
       this.logger.info(
-        `Attempting to find an appropriate L1 block height to begin sync...`
+        'Attempting to find an appropriate L1 block height to begin sync...'
       )
       this.state.startingL1BlockNumber = await this._findStartingL1BlockNumber()
-      this.logger.info(
-        `Starting sync at block ${colors.yellow(
-          `${this.state.startingL1BlockNumber}`
-        )}`
-      )
+      this.logger.info('Starting sync', {
+        startingL1BlockNumber: this.state.startingL1BlockNumber,
+      })
 
       await this.state.db.setStartingL1Block(this.state.startingL1BlockNumber)
     }
@@ -161,11 +161,10 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
           continue
         }
 
-        this.logger.info(
-          `Synchronizing events from Layer 1 (Ethereum) from block ${colors.yellow(
-            `${highestSyncedL1Block}`
-          )} to block ${colors.yellow(`${targetL1Block}`)}`
-        )
+        this.logger.info('Synchronizing events from Layer 1 (Ethereum)', {
+          highestSyncedL1Block,
+          targetL1Block,
+        })
 
         // I prefer to do this in serial to avoid non-determinism. We could have a discussion about
         // using Promise.all if necessary, but I don't see a good reason to do so unless parsing is
@@ -204,7 +203,7 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
         }
       } catch (err) {
         if (!this.running || this.options.dangerouslyCatchAllErrors) {
-          this.logger.error(`Caught an unhandled error: ${err}`)
+          this.logger.error('Caught an unhandled error', { err })
           await sleep(this.options.pollingInterval)
         } else {
           // TODO: Is this the best thing to do here?
@@ -301,11 +300,11 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
 
         const tock = Date.now()
 
-        this.logger.success(
-          `Processed ${colors.magenta(`${events.length}`)} ${colors.cyan(
-            eventName
-          )} events in ${colors.red(`${tock - tick}ms`)}.`
-        )
+        this.logger.info('Processed events', {
+          eventName,
+          numEvents: events.length,
+          durationMs: tock - tick,
+        })
       }
     }
   }

--- a/src/services/l2-ingestion/service.ts
+++ b/src/services/l2-ingestion/service.ts
@@ -60,8 +60,8 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
 
   protected async _init(): Promise<void> {
     if (this.options.legacySequencerCompatibility) {
-      this.logger.interesting(
-        `Using legacy sync, this will be quite a bit slower than normal`
+      this.logger.info(
+        'Using legacy sync, this will be quite a bit slower than normal'
       )
     }
 
@@ -85,8 +85,8 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
           this.options.stopL2SyncAtBlock !== null &&
           highestSyncedL2BlockNumber >= this.options.stopL2SyncAtBlock
         ) {
-          this.logger.interesting(
-            `L2 sync is shutting down because we've reached your target block. Goodbye!`
+          this.logger.info(
+            "L2 sync is shutting down because we've reached your target block. Goodbye!"
           )
           return
         }
@@ -143,7 +143,7 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
         }
       } catch (err) {
         if (!this.running || this.options.dangerouslyCatchAllErrors) {
-          this.logger.error(`Caught an unhandled error: ${err}`)
+          this.logger.error('Caught an unhandled error', { err })
           await sleep(this.options.pollingInterval)
         } else {
           // TODO: Is this the best thing to do here?
@@ -163,9 +163,12 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
     endBlockNumber: number
   ): Promise<void> {
     if (startBlockNumber > endBlockNumber) {
-      this.logger.info(
-        `Cannot query with start block number ${startBlockNumber}` +
-          `larger than end block number ${endBlockNumber}`
+      this.logger.warn(
+        'Cannot query with start block number larger than end block number',
+        {
+          startBlockNumber,
+          endBlockNumber,
+        }
       )
       return
     }

--- a/src/services/server/service.ts
+++ b/src/services/server/service.ts
@@ -79,7 +79,10 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
       this.options.port,
       this.options.hostname
     )
-    this.logger.info(`Server listening on port: ${this.options.port}`)
+    this.logger.info('Server started and listening', {
+      host: this.options.hostname,
+      port: this.options.port,
+    })
   }
 
   protected async _stop(): Promise<void> {
@@ -115,7 +118,11 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
 
     this.state.app[method](route, async (req, res) => {
       try {
-        this.logger.info(`${req.ip}: ${method.toUpperCase()} ${req.path}`)
+        this.logger.info('Registered route', {
+          ip: req.ip,
+          method: method.toUpperCase(),
+          path: req.path,
+        })
         return res.json(await handler(req, res))
       } catch (e) {
         return res.status(400).json({


### PR DESCRIPTION
In the spirit of improved observability, this refactors log messages to split apart the message from the context.
