### PR TITLE
fix: Remove default Chain ID

### DIFF
--- a/src/services/run.ts
+++ b/src/services/run.ts
@@ -36,7 +36,7 @@ interface Bcfg {
         false
       ),
       l2RpcProvider: config.str('l2RpcEndpoint'),
-      l2ChainId: config.uint('l2ChainId', 69),
+      l2ChainId: config.uint('l2ChainId'),
       syncFromL1: config.bool('syncFromL1', true),
       syncFromL2: config.bool('syncFromL2', false),
       showUnconfirmedTransactions: config.bool('syncFromL2', false),


### PR DESCRIPTION
Having a hardcoded default Chain ID tends to cause a lot of issues for users who don't realize that the value has a default, especially if that default is wrong. This PR removes the default and forces users to provide the Chain ID as an explicit input.