### PR TITLE
fix: Bump default confs to 35

### DIFF
--- a/src/services/l1-ingestion/service.ts
+++ b/src/services/l1-ingestion/service.ts
@@ -40,7 +40,7 @@ export class L1IngestionService extends BaseService<L1IngestionServiceOptions> {
       validate: validators.isAddress,
     },
     confirmations: {
-      default: 12,
+      default: 35,
       validate: validators.isInteger,
     },
     pollingInterval: {

--- a/src/services/run.ts
+++ b/src/services/run.ts
@@ -26,7 +26,7 @@ interface Bcfg {
       dbPath: config.str('dbPath', './db'),
       port: config.uint('serverPort', 7878),
       hostname: config.str('serverHostname', 'localhost'),
-      confirmations: config.uint('confirmations', 12),
+      confirmations: config.uint('confirmations'),
       l1RpcProvider: config.str('l1RpcEndpoint'),
       addressManager: config.str('addressManager'),
       pollingInterval: config.uint('pollingInterval', 5000),

--- a/src/services/run.ts
+++ b/src/services/run.ts
@@ -26,7 +26,7 @@ interface Bcfg {
       dbPath: config.str('dbPath', './db'),
       port: config.uint('serverPort', 7878),
       hostname: config.str('serverHostname', 'localhost'),
-      confirmations: config.uint('confirmations'),
+      confirmations: config.uint('confirmations', 35),
       l1RpcProvider: config.str('l1RpcEndpoint'),
       addressManager: config.str('addressManager'),
       pollingInterval: config.uint('pollingInterval', 5000),


### PR DESCRIPTION
Default of 12 is too low. 35 is much safer. Possible addition here would be to add a warning log if a confirmation depth < ~15 is used.