### PR TITLE
feature: query params for selectable backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/node-fetch": "^2.5.8",
     "@types/rimraf": "^3.0.0",
     "hardhat": "^2.0.9",
+    "pino-pretty": "^4.7.1",
     "rimraf": "^3.0.2",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.3"

--- a/src/services/l2-ingestion/service.ts
+++ b/src/services/l2-ingestion/service.ts
@@ -47,10 +47,6 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
       default: false,
       validate: validators.isBoolean,
     },
-    stopL2SyncAtBlock: {
-      default: Infinity,
-      validate: validators.isInteger,
-    },
   }
 
   private state: {
@@ -79,34 +75,11 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
         const highestSyncedL2BlockNumber =
           (await this.state.db.getHighestSyncedUnconfirmedBlock()) || 1
 
-        // Shut down if we're at the stop block.
-        if (
-          this.options.stopL2SyncAtBlock !== undefined &&
-          this.options.stopL2SyncAtBlock !== null &&
-          highestSyncedL2BlockNumber >= this.options.stopL2SyncAtBlock
-        ) {
-          this.logger.info(
-            "L2 sync is shutting down because we've reached your target block. Goodbye!"
-          )
-          return
-        }
-
         // Subtract one to account for the CTC being zero indexed
-        let currentL2Block = Math.max(
+        const currentL2Block = Math.max(
           (await this.state.l2RpcProvider.getBlockNumber()) - 1,
           0
         )
-
-        // Make sure we can't exceed the stop block.
-        if (
-          this.options.stopL2SyncAtBlock !== undefined &&
-          this.options.stopL2SyncAtBlock !== null
-        ) {
-          currentL2Block = Math.min(
-            currentL2Block,
-            this.options.stopL2SyncAtBlock
-          )
-        }
 
         // Make sure we don't exceed the tip.
         const targetL2Block = Math.min(

--- a/src/services/server/service.ts
+++ b/src/services/server/service.ts
@@ -62,7 +62,6 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
   } = {} as any
 
   protected async _init(): Promise<void> {
-    // TODO: I don't know if this is strictly necessary, but it's probably a good thing to do.
     if (!this.options.db.isOpen()) {
       await this.options.db.open()
     }
@@ -100,9 +99,6 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
     // TODO: Maybe pass this in as a parameter instead of creating it here?
     this.state.app = express()
     this.state.app.use(cors())
-    this.state.app.use(expressPinoLogger({
-      logger: this.logger.inner
-    }))
     this._registerAllRoutes()
   }
 
@@ -122,9 +118,26 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
     // TODO: Add a different function to allow for removing routes.
 
     this.state.app[method](route, async (req, res) => {
+      const start = Date.now()
       try {
-        return res.json(await handler(req, res))
+        const json = await handler(req, res)
+        const elapsed = new Date().getTime() - start
+        this.logger.info('Served HTTP Request', {
+          method: req.method,
+          url: req.url,
+          query: req.query,
+          elapsed,
+        })
+        return res.json(json)
       } catch (e) {
+        const elapsed = Date.now() - start
+        this.logger.info('Failed HTTP Request', {
+          method: req.method,
+          url: req.url,
+          query: req.query,
+          elapsed,
+          msg: e.toString()
+        })
         return res.status(400).json({
           error: e.toString(),
         })
@@ -139,6 +152,7 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
   private _registerAllRoutes(): void {
     // TODO: Maybe add doc-like comments to each of these routes?
 
+    // TODO: this needs a backend argument
     this._registerRoute(
       'get',
       '/eth/syncing',
@@ -295,21 +309,19 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
     this._registerRoute(
       'get',
       '/transaction/latest',
-      async (): Promise<TransactionResponse> => {
-        let transaction = await this.state.db.getLatestFullTransaction()
-        if (this.options.showUnconfirmedTransactions) {
-          const latestUnconfirmedTx = await this.state.db.getLatestUnconfirmedTransaction()
-          if (
-            transaction === null ||
-            transaction === undefined ||
-            latestUnconfirmedTx.index >= transaction.index
-          ) {
-            transaction = latestUnconfirmedTx
-          }
-        }
+      async (req): Promise<TransactionResponse> => {
+        const backend = req.query.backend || 'l1'
+        let transaction = null
 
-        if (transaction === null) {
-          transaction = await this.state.db.getLatestFullTransaction()
+        switch (backend) {
+          case 'l1':
+            transaction = await this.state.db.getLatestFullTransaction()
+              break
+          case 'l2':
+            transaction = await this.state.db.getLatestUnconfirmedTransaction()
+            break
+          default:
+            throw new Error(`Unknown backend type ${backend}`)
         }
 
         if (transaction === null) {
@@ -334,17 +346,22 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
       'get',
       '/transaction/index/:index',
       async (req): Promise<TransactionResponse> => {
+        const backend = req.query.backend || 'l1'
         let transaction = null
-        if (this.options.showUnconfirmedTransactions) {
-          transaction = await this.state.db.getUnconfirmedTransactionByIndex(
-            BigNumber.from(req.params.index).toNumber()
-          )
-        }
 
-        if (transaction === null) {
-          transaction = await this.state.db.getFullTransactionByIndex(
-            BigNumber.from(req.params.index).toNumber()
-          )
+        switch (backend) {
+          case 'l1':
+            transaction = await this.state.db.getFullTransactionByIndex(
+              BigNumber.from(req.params.index).toNumber()
+            )
+            break
+          case 'l2':
+            transaction = await this.state.db.getUnconfirmedTransactionByIndex(
+              BigNumber.from(req.params.index).toNumber()
+            )
+            break
+          default:
+            throw new Error(`Unknown backend type ${backend}`)
         }
 
         if (transaction === null) {
@@ -422,21 +439,19 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
     this._registerRoute(
       'get',
       '/stateroot/latest',
-      async (): Promise<StateRootResponse> => {
-        let stateRoot = await this.state.db.getLatestStateRoot()
-        if (this.options.showUnconfirmedTransactions) {
-          const latestUnconfirmedStateRoot = await this.state.db.getLatestUnconfirmedStateRoot()
-          if (
-            stateRoot === null ||
-            stateRoot === undefined ||
-            latestUnconfirmedStateRoot.index >= stateRoot.index
-          ) {
-            stateRoot = latestUnconfirmedStateRoot
-          }
-        }
+      async (req): Promise<StateRootResponse> => {
+        const backend = req.query.backend || 'l1'
+        let stateRoot = null
 
-        if (stateRoot === null) {
-          stateRoot = await this.state.db.getLatestStateRoot()
+        switch (backend) {
+          case 'l1':
+            stateRoot = await this.state.db.getLatestStateRoot()
+            break
+          case 'l2':
+            stateRoot = await this.state.db.getLatestUnconfirmedStateRoot()
+            break
+          default:
+            throw new Error(`Unknown backend type ${backend}`)
         }
 
         if (stateRoot === null) {
@@ -461,17 +476,22 @@ export class L1TransportServer extends BaseService<L1TransportServerOptions> {
       'get',
       '/stateroot/index/:index',
       async (req): Promise<StateRootResponse> => {
+        const backend = req.query.backend || 'l1'
         let stateRoot = null
-        if (this.options.showUnconfirmedTransactions) {
-          stateRoot = await this.state.db.getUnconfirmedStateRootByIndex(
-            BigNumber.from(req.params.index).toNumber()
-          )
-        }
 
-        if (stateRoot === null) {
-          stateRoot = await this.state.db.getStateRootByIndex(
-            BigNumber.from(req.params.index).toNumber()
-          )
+        switch (backend) {
+          case 'l1':
+            stateRoot = await this.state.db.getStateRootByIndex(
+              BigNumber.from(req.params.index).toNumber()
+            )
+            break
+          case 'l2':
+            stateRoot = await this.state.db.getUnconfirmedStateRootByIndex(
+              BigNumber.from(req.params.index).toNumber()
+            )
+            break
+          default:
+            throw new Error(`Unknown backend type ${backend}`)
         }
 
         if (stateRoot === null) {


### PR DESCRIPTION
This adds a query param to the transaction and state root routes `backend` where it can be `l1` or `l2`. This allows the client to decide what to query. It also removes the `pino-express-logger` and just uses pino directly and logs the important things that needed to be logged. This was because `pino-express-logger` would log a bunch of things that weren't useful and `pino-pretty` didn't allow for dotpath syntax to remove nested objects like headers, which isn't particularly useful to us because we don't do anything with headers.