### PR TITLE
refactor: remove unnecessary asyncronous wrapper around syncronous code

### DIFF
--- a/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
+++ b/src/services/l1-ingestion/handlers/sequencer-batch-appended.ts
@@ -93,7 +93,7 @@ export const handleEventsSequencerBatchAppended: EventHandlerSet<
       batchExtraData: batchSubmissionEvent.args._extraData,
     }
   },
-  parseEvent: async (event, extraData) => {
+  parseEvent: (event, extraData) => {
     const transactionEntries: TransactionEntry[] = []
 
     // It's easier to deal with this data if it's a Buffer.

--- a/src/services/l1-ingestion/handlers/state-batch-appended.ts
+++ b/src/services/l1-ingestion/handlers/state-batch-appended.ts
@@ -36,7 +36,7 @@ export const handleEventsStateBatchAppended: EventHandlerSet<
       l1TransactionData: l1Transaction.data,
     }
   },
-  parseEvent: async (event, extraData) => {
+  parseEvent: (event, extraData) => {
     const stateRoots = getContractFactory(
       'OVM_StateCommitmentChain'
     ).interface.decodeFunctionData(

--- a/src/services/l1-ingestion/handlers/transaction-enqueued.ts
+++ b/src/services/l1-ingestion/handlers/transaction-enqueued.ts
@@ -14,7 +14,7 @@ export const handleEventsTransactionEnqueued: EventHandlerSet<
   getExtraData: async () => {
     return null
   },
-  parseEvent: async (event) => {
+  parseEvent: (event) => {
     return {
       index: event.args._queueIndex.toNumber(),
       target: event.args._target,

--- a/src/types/event-handler-types.ts
+++ b/src/types/event-handler-types.ts
@@ -10,7 +10,7 @@ export type GetExtraDataHandler<TEventArgs, TExtraData> = (
 export type ParseEventHandler<TEventArgs, TExtraData, TParsedEvent> = (
   event: TypedEthersEvent<TEventArgs>,
   extraData: TExtraData
-) => Promise<TParsedEvent>
+) => TParsedEvent
 
 export type StoreEventHandler<TParsedEvent> = (
   parsedEvent: TParsedEvent,

--- a/test/unit-tests/services/l1-ingestion/handlers/transaction-enqueued.spec.ts
+++ b/test/unit-tests/services/l1-ingestion/handlers/transaction-enqueued.spec.ts
@@ -22,7 +22,7 @@ describe('Event Handlers: OVM_CanonicalTransactionChain.TransactionEnqueued', ()
     // to test. We could add a lot more tests that guarantee the correctness of the provided input,
     // but it's probably better to get wider test coverage first.
 
-    it('should have a ctcIndex equal to null', async () => {
+    it('should have a ctcIndex equal to null', () => {
       const input1: [any, any] = [
         {
           blockNumber: 0,
@@ -35,7 +35,7 @@ describe('Event Handlers: OVM_CanonicalTransactionChain.TransactionEnqueued', ()
         null,
       ]
 
-      const output1 = await handleEventsTransactionEnqueued.parseEvent(
+      const output1 = handleEventsTransactionEnqueued.parseEvent(
         ...input1
       )
 
@@ -44,7 +44,7 @@ describe('Event Handlers: OVM_CanonicalTransactionChain.TransactionEnqueued', ()
       expect(output1).to.have.property('ctcIndex', expected1)
     })
 
-    it('should have a blockNumber equal to the integer value of the blockNumber parameter', async () => {
+    it('should have a blockNumber equal to the integer value of the blockNumber parameter', () => {
       for (
         let i = 0;
         i < Number.MAX_SAFE_INTEGER;
@@ -62,7 +62,7 @@ describe('Event Handlers: OVM_CanonicalTransactionChain.TransactionEnqueued', ()
           null,
         ]
 
-        const output1 = await handleEventsTransactionEnqueued.parseEvent(
+        const output1 = handleEventsTransactionEnqueued.parseEvent(
           ...input1
         )
 
@@ -72,7 +72,7 @@ describe('Event Handlers: OVM_CanonicalTransactionChain.TransactionEnqueued', ()
       }
     })
 
-    it('should have an index equal to the integer value of the _queueIndex argument', async () => {
+    it('should have an index equal to the integer value of the _queueIndex argument', () => {
       for (
         let i = 0;
         i < Number.MAX_SAFE_INTEGER;
@@ -90,7 +90,7 @@ describe('Event Handlers: OVM_CanonicalTransactionChain.TransactionEnqueued', ()
           null,
         ]
 
-        const output1 = await handleEventsTransactionEnqueued.parseEvent(
+        const output1 = handleEventsTransactionEnqueued.parseEvent(
           ...input1
         )
 
@@ -100,7 +100,7 @@ describe('Event Handlers: OVM_CanonicalTransactionChain.TransactionEnqueued', ()
       }
     })
 
-    it('should have a gasLimit equal to the integer value of the _gasLimit argument', async () => {
+    it('should have a gasLimit equal to the integer value of the _gasLimit argument', () => {
       for (
         let i = 0;
         i < Number.MAX_SAFE_INTEGER;
@@ -118,7 +118,7 @@ describe('Event Handlers: OVM_CanonicalTransactionChain.TransactionEnqueued', ()
           null,
         ]
 
-        const output1 = await handleEventsTransactionEnqueued.parseEvent(
+        const output1 = handleEventsTransactionEnqueued.parseEvent(
           ...input1
         )
 
@@ -128,7 +128,7 @@ describe('Event Handlers: OVM_CanonicalTransactionChain.TransactionEnqueued', ()
       }
     })
 
-    it('should have a timestamp equal to the integer value of the _timestamp argument', async () => {
+    it('should have a timestamp equal to the integer value of the _timestamp argument', () => {
       for (
         let i = 0;
         i < Number.MAX_SAFE_INTEGER;
@@ -146,7 +146,7 @@ describe('Event Handlers: OVM_CanonicalTransactionChain.TransactionEnqueued', ()
           null,
         ]
 
-        const output1 = await handleEventsTransactionEnqueued.parseEvent(
+        const output1 = handleEventsTransactionEnqueued.parseEvent(
           ...input1
         )
 


### PR DESCRIPTION
`parseEvent` was always syncronous, thus the asyncronous wrapper was unnecessary.
