### PR TITLE
l2-service: fix trailing by one bug

### DIFF
--- a/src/services/l2-ingestion/service.ts
+++ b/src/services/l2-ingestion/service.ts
@@ -91,11 +91,7 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
           return
         }
 
-        // Subtract one to account for the CTC being zero indexed
-        let currentL2Block = Math.max(
-          (await this.state.l2RpcProvider.getBlockNumber()) - 1,
-          0
-        )
+        let currentL2Block = await this.state.l2RpcProvider.getBlockNumber()
 
         // Make sure we can't exceed the stop block.
         if (


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
There currently exists a bug by which the data-transport-layer doesn't sync exactly to the tip. It constantly stays one block behind the tip. This fixes that bug. The off by one is accounted for in `handleSequencerBlock`

**Additional context**
This is required to unblock infra providers

**Metadata**
- Fixes #[Link to Issue]
